### PR TITLE
Removed i386 from OS X x86_64

### DIFF
--- a/pd-lib-builder/Makefile.pdlibbuilder
+++ b/pd-lib-builder/Makefile.pdlibbuilder
@@ -577,7 +577,7 @@ ifeq ($(system), Darwin)
     version.flag = -mmacosx-version-min=10.4
   endif
   ifeq ($(target.arch), x86_64)
-    arch := i386 x86_64
+    arch := x86_64
     version.flag = -mmacosx-version-min=10.5
   endif
   ifneq ($(filter -mmacosx-version-min=%, $(cflags)),)


### PR DESCRIPTION
When trying to build on OS X 10.14 with XCode 10 I get the following error:

```
ld: in '/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.14.sdk/usr/lib/system/libcache.tbd', missing required architecture i386 in file /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.14.sdk/usr/lib/system/libcache.tbd for architecture i386
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```
As far as I have researched, it seems like this is caused by i386 being removed from XCode 10:

https://developer.apple.com/documentation/xcode_release_notes/xcode_10_release_notes

When i remove 'i386' from line 580 it works.